### PR TITLE
fix: Add unique origin entity code

### DIFF
--- a/docs/4.4.1-release-notes.md
+++ b/docs/4.4.1-release-notes.md
@@ -3,3 +3,4 @@
 - Terminology changes
 
 ### Fix
+- Fix Topology not showing data from enricher

--- a/src/ExternalSearch.Providers.CVR/CVRExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.CVR/CVRExternalSearchProvider.cs
@@ -186,9 +186,12 @@ namespace CluedIn.ExternalSearch.Providers.CVR
         /// <param name="resultItem">The result item.</param>
         private void PopulateMetadata(IEntityMetadata metadata, IExternalSearchQueryResult<CvrResult> resultItem, IExternalSearchRequest request)
         {
+            var code = new EntityCode(request.EntityMetaData.OriginEntityCode.Type, "CVR", $"{request.Queries.FirstOrDefault()?.QueryKey}{request.EntityMetaData.OriginEntityCode}".ToDeterministicGuid());
+
             metadata.EntityType             = request.EntityMetaData.EntityType;
             metadata.Name                   = request.EntityMetaData.Name;
-            metadata.OriginEntityCode       = request.EntityMetaData.OriginEntityCode;
+            metadata.OriginEntityCode       = code;
+            metadata.Codes.Add(request.EntityMetaData.OriginEntityCode);
 
             metadata.Aliases.AddRange(resultItem.Data.Organization.AlternateNames);
 
@@ -408,9 +411,14 @@ namespace CluedIn.ExternalSearch.Providers.CVR
         {
             var resultItem = result.As<CvrResult>();
 
-
-            var clue = new Clue(request.EntityMetaData.OriginEntityCode, context.Organization);
-            clue.Data.OriginProviderDefinitionId = this.Id;
+            var code = new EntityCode(request.EntityMetaData.OriginEntityCode.Type, "CVR", $"{query.QueryKey}{request.EntityMetaData.OriginEntityCode}".ToDeterministicGuid());
+            var clue = new Clue(code, context.Organization)
+            {
+                Data =
+                {
+                    OriginProviderDefinitionId = Id
+                }
+            };
 
             this.PopulateMetadata(clue.Data.EntityData, resultItem, request);
 


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: AB#47706

Topology now showing CVR data, but the one from other enricher turn into no source (Logo having issue)
![image](https://github.com/user-attachments/assets/5f23bb6d-ce36-49ab-b47d-14e033303328)

## How has it been tested? <!-- Remove if not needed -->
Manually in local

