### PR TITLE
feat: Update to .NET 10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup Label="Compilation Metadata">
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <!-- TODO: Clean up warnings -->

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 mode: ContinuousDeployment
-next-version: 4.0
+next-version: 5.0
 branches:
   master:
     mode: ContinuousDelivery

--- a/Packages.props
+++ b/Packages.props
@@ -1,38 +1,30 @@
 <Project>
   <PropertyGroup Label="Dependency Versions">
-    <_ComponentHost>3.2.1</_ComponentHost>
-    <_AutoFixture>4.11.0</_AutoFixture>
-    <_CluedIn>4.6.0</_CluedIn>
+    <_AutoFixture>5.0.0-preview0012</_AutoFixture>
+    <_CluedIn>5.0.0-*</_CluedIn>
   </PropertyGroup>
   <ItemGroup>
     <!--
         Specified versions for dependencies in test projects
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Update="AutoFixture.Xunit2" Version="$(_AutoFixture)" />
-    <PackageReference Update="AutoFixture.Idioms" Version="$(_AutoFixture)" />
-    <PackageReference Update="AutoFixture.AutoMoq" Version="$(_AutoFixture)" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Update="AutoFixture.Xunit3" Version="$(_AutoFixture)" />
     <PackageReference Update="coverlet.msbuild" Version="2.8.0" />
-    <PackageReference Update="Serilog.Sinks.XUnit" Version="1.0.21" />
-    <PackageReference Update="xunit" Version="2.4.1" />
-    <PackageReference Update="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Update="xunit.v3" Version="3.2.2" />
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Update="Moq" Version="4.13.1" />
     <PackageReference Update="Shouldly" Version="3.0.2" />
-    <PackageReference Update="CluedIn.Testing.Base" Version="4.0.0" />
+    <PackageReference Update="CluedIn.Testing.Base" Version="5.0.0-*" />
   </ItemGroup>
   <ItemGroup>
     <!--
         Specified versions for dependencies across the solution
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <PackageReference Update="ComponentHost" Version="$(_ComponentHost)" />
     <PackageReference Update="CluedIn.Crawling" Version="$(_CluedIn)" />
-    <PackageReference Update="CluedIn.CrawlerIntegrationTesting" Version="4.0.0" />
+    <PackageReference Update="CluedIn.CrawlerIntegrationTesting" Version="5.0.0-*" />
     <PackageReference Update="CluedIn.Core" Version="$(_CluedIn)" />
-    <PackageReference Update="CluedIn.Core.Agent" Version="$(_CluedIn)" />
-    <PackageReference Update="CluedIn.Server" Version="$(_CluedIn)" />
-    <PackageReference Update="CluedIn.Server.Common.WebApi" Version="$(_CluedIn)" />
     <PackageReference Update="CluedIn.ExternalSearch" Version="$(_CluedIn)" />
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,8 +1,7 @@
 {
   "sdk": {
-    "version": "6.0.400",
-    "rollForward": "latestFeature",
-    "allowPrerelease": "false"
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.52"

--- a/src/ExternalSearch.Providers.CVR.Provider/Provider.ExternalSearch.CVR.csproj
+++ b/src/ExternalSearch.Providers.CVR.Provider/Provider.ExternalSearch.CVR.csproj
@@ -1,11 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-		<LangVersion>latest</LangVersion>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-		<LangVersion>latest</LangVersion>
-	</PropertyGroup>
 
     <ItemGroup>
         <None Remove="D:\Projects\CluedIn\CluedIn.Enricher.CVR\build\assets\nugetlogo.png" />

--- a/src/ExternalSearch.Providers.CVR.Provider/Provider.ExternalSearch.CVR.csproj
+++ b/src/ExternalSearch.Providers.CVR.Provider/Provider.ExternalSearch.CVR.csproj
@@ -6,7 +6,6 @@
 
     <ItemGroup>
         <PackageReference Include="CluedIn.Core" />
-        <PackageReference Include="ComponentHost" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ExternalSearch.Providers.CVR/CVRExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.CVR/CVRExternalSearchProvider.cs
@@ -122,7 +122,7 @@ namespace CluedIn.ExternalSearch.Providers.CVR
             {
                 var hosts = website.Where(UriUtility.IsValid).Select(u => new Uri(u).Host.ToLowerInvariant()).Distinct();
 
-                if (hosts.Any(h => DomainName.TryParse(h, out var domain) && string.Equals(domain.TLD, "dk", StringComparison.InvariantCultureIgnoreCase)))
+                if (hosts.Any(h => DomainName.TryParse(h, out var domain) && string.Equals(domain.TopLevelDomain, "dk", StringComparison.InvariantCultureIgnoreCase)))
                     namePostFixFilter = _ => false;
             }
 
@@ -321,7 +321,7 @@ namespace CluedIn.ExternalSearch.Providers.CVR
             }
         }
 
-        private ConnectionVerificationResult ConstructVerifyConnectionResponse(IRestResponse response)
+        private ConnectionVerificationResult ConstructVerifyConnectionResponse(RestResponse response)
         {
             var errorMessageBase = $"{Constants.ProviderName} returned \"{(int)response.StatusCode} {response.StatusDescription}\".";
             if (response.StatusCode is HttpStatusCode.Unauthorized)
@@ -483,16 +483,16 @@ namespace CluedIn.ExternalSearch.Providers.CVR
                     }
                 }).Trim();
 
-            var client = new RestClient(endpoint);
-            var request = new RestRequest(Method.POST);
-
             var userInfo = endpoint.UserInfo;
+            NetworkCredential credentials = null;
             if (!string.IsNullOrEmpty(userInfo))
             {
                 var parts = userInfo.Split(':');
-
-                request.Credentials = new NetworkCredential(parts[0], parts[1]);
+                credentials = new NetworkCredential(parts[0], parts[1]);
             }
+
+            var client = new RestClient(new RestClientOptions(endpoint) { Credentials = credentials });
+            var request = new RestRequest { Method = Method.Post };
 
             request.AddParameter("application/json", body, ParameterType.RequestBody);
 
@@ -523,14 +523,7 @@ namespace CluedIn.ExternalSearch.Providers.CVR
                 }
             });
 
-            request = new RestRequest(Method.POST);
-
-            if (!string.IsNullOrEmpty(userInfo))
-            {
-                var parts = userInfo.Split(':');
-
-                request.Credentials = new NetworkCredential(parts[0], parts[1]);
-            }
+            request = new RestRequest { Method = Method.Post };
 
             request.AddParameter("application/json", searchByNameBody, ParameterType.RequestBody);
             var searchByNameResponse = client.Execute<CompanyResult>(request);

--- a/src/ExternalSearch.Providers.CVR/Client/CvrClient.Cvr.cs
+++ b/src/ExternalSearch.Providers.CVR/Client/CvrClient.Cvr.cs
@@ -134,7 +134,7 @@ namespace CluedIn.ExternalSearch.Providers.CVR.Client
             );
         }
 
-        private IEnumerable<Result<CvrOrganization>> BuildHits(IEnumerable<Hit> hits, IRestResponse<CompanyResult> response, JObject json, string name, bool matchPastNames)
+        private IEnumerable<Result<CvrOrganization>> BuildHits(IEnumerable<Hit> hits, RestResponse<CompanyResult> response, JObject json, string name, bool matchPastNames)
         {
             if (hits == null || string.IsNullOrEmpty(name)) yield break;
 
@@ -143,19 +143,19 @@ namespace CluedIn.ExternalSearch.Providers.CVR.Client
             yield return CreateCompanyResult(hit, json);
         }
 
-        private T GetCompanyResult<T>(string queryBody, Uri endPoint, Func<IEnumerable<Hit>, IRestResponse<CompanyResult>, JObject, string, bool, T> resultFunc, string name, bool matchPastNames)
+        private T GetCompanyResult<T>(string queryBody, Uri endPoint, Func<IEnumerable<Hit>, RestResponse<CompanyResult>, JObject, string, bool, T> resultFunc, string name, bool matchPastNames)
         {
-            var client = new RestClient(endPoint);
-
-            var request = new RestRequest(Method.POST);
-
             var userInfo = endPoint.UserInfo;
+            NetworkCredential credentials = null;
             if (!string.IsNullOrEmpty(userInfo))
             {
                 var parts = userInfo.Split(':');
-
-                request.Credentials = new NetworkCredential(parts[0], parts[1]);
+                credentials = new NetworkCredential(parts[0], parts[1]);
             }
+
+            var client = new RestClient(new RestClientOptions(endPoint) { Credentials = credentials });
+
+            var request = new RestRequest { Method = Method.Post };
 
             var body = queryBody.Trim();
 

--- a/src/ExternalSearch.Providers.CVR/Client/CvrClient.FinancialReport.cs
+++ b/src/ExternalSearch.Providers.CVR/Client/CvrClient.FinancialReport.cs
@@ -14,7 +14,7 @@ namespace CluedIn.ExternalSearch.Providers.CVR.Client
         public Result<Offentliggoerelse> GetFinancialYearlyReport(int cvrNumber)
         {
             var client  = new RestClient("http://distribution.virk.dk/offentliggoerelser/_search");
-            var request = new RestRequest(Method.POST);
+            var request = new RestRequest { Method = Method.Post };
 
             var body = $$$"""
                             { "from" : 0, "size" : 1,

--- a/src/ExternalSearch.Providers.CVR/Client/CvrClient.Xbrl.cs
+++ b/src/ExternalSearch.Providers.CVR/Client/CvrClient.Xbrl.cs
@@ -20,7 +20,7 @@ namespace CluedIn.ExternalSearch.Providers.CVR.Client
             // sitecore danmark - "http://regnskaber.virk.dk/46897513/ZG9rdW1lbnRsYWdlcjovLzAzLzJmLzM1L2MxLzIzL2E4ZmMtNDRhNC05ZTU0LWJlZDc3NTI5MmZhYw.xml"
 
             var client  = new RestClient(url);
-            var request = new RestRequest(Method.GET);
+            var request = new RestRequest { Method = Method.Get };
 
             var response = client.Execute<XbrlResponse>(request);
 

--- a/src/ExternalSearch.Providers.CVR/ExternalSearch.Providers.CVR.csproj
+++ b/src/ExternalSearch.Providers.CVR/ExternalSearch.Providers.CVR.csproj
@@ -5,19 +5,9 @@
   <ItemGroup>
     <EmbeddedResource Include="Resources\logo.svg" />
   </ItemGroup>
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-        <LangVersion>latest</LangVersion>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-        <LangVersion>latest</LangVersion>
-    </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CluedIn.ExternalSearch" />
     <PackageReference Include="CluedIn.Crawling" />
     <PackageReference Include="CluedIn.Core" />
   </ItemGroup>
-  <PropertyGroup>
-	<LangVersion>preview</LangVersion>
-  </PropertyGroup>
 </Project>

--- a/src/ExternalSearch.Providers.CVR/Net/DomainName.cs
+++ b/src/ExternalSearch.Providers.CVR/Net/DomainName.cs
@@ -2,14 +2,16 @@
 
 using System.Diagnostics.CodeAnalysis;
 using Nager.PublicSuffix;
+using Nager.PublicSuffix.Exceptions;
+using Nager.PublicSuffix.RuleProviders;
 
 namespace CluedIn.ExternalSearch.Providers.CVR.Net;
 
 internal static class DomainName
 {
-    private static readonly DomainParser domainParser = new(new WebTldRuleProvider());
+    private static readonly DomainParser domainParser = new(new SimpleHttpRuleProvider());
 
-    public static bool TryParse(string domain, [NotNullWhen(true)]out DomainInfo? domainInfo)
+    public static bool TryParse(string domain, [NotNullWhen(true)] out DomainInfo? domainInfo)
     {
         try
         {

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.Xunit2" />
+    <PackageReference Include="AutoFixture.Xunit3" />
     <PackageReference Include="coverlet.msbuild" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Moq" />
   </ItemGroup>

--- a/test/integration/ExternalSearch.CVR.Integration.Tests/CvrTests.cs
+++ b/test/integration/ExternalSearch.CVR.Integration.Tests/CvrTests.cs
@@ -17,10 +17,10 @@ using CluedIn.Core.Serialization;
 using CluedIn.Core.Workflows;
 using CluedIn.ExternalSearch;
 using CluedIn.ExternalSearch.Providers.CVR;
-using CluedIn.Testing.Base.Context;
 using CluedIn.Testing.Base.Processing.Actors;
 using Moq;
 using Xunit;
+using TestContext = CluedIn.Testing.Base.Context.TestContext;
 
 namespace ExternalSearch.CVR.Integration.Tests
 {
@@ -63,10 +63,10 @@ namespace ExternalSearch.CVR.Integration.Tests
             context.Workflow       = command.Workflow;
 
             // Act
-            var result = actor.ProcessWorkflowStep(context, command);
+            var result = actor.ProcessWorkflowStepAsync(context, command).GetAwaiter().GetResult();
             Assert.Equal(WorkflowStepResult.Repeat.SaveResult, result.SaveResult);
 
-            result = actor.ProcessWorkflowStep(context, command);
+            result = actor.ProcessWorkflowStepAsync(context, command).GetAwaiter().GetResult();
             Assert.Equal(WorkflowStepResult.Success.SaveResult, result.SaveResult);
             context.Workflow.AddStepResult(result);
 
@@ -115,10 +115,10 @@ namespace ExternalSearch.CVR.Integration.Tests
             context.Workflow       = command.Workflow;
 
             // Act
-            var result = actor.ProcessWorkflowStep(context, command);
+            var result = actor.ProcessWorkflowStepAsync(context, command).GetAwaiter().GetResult();
             Assert.Equal(WorkflowStepResult.Repeat.SaveResult, result.SaveResult);
 
-            result = actor.ProcessWorkflowStep(context, command);
+            result = actor.ProcessWorkflowStepAsync(context, command).GetAwaiter().GetResult();
             Assert.Equal(WorkflowStepResult.Success.SaveResult, result.SaveResult);
             context.Workflow.AddStepResult(result);
 


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
Work Item ID: [AB#56314](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/56314)

Upgrade to .NET 10 (`net10.0`) and align with CluedIn platform 5.0.

- `global.json`: SDK updated to `10.0.100` with `rollForward: latestFeature`
- `Directory.Build.props`: `TargetFramework` changed to `net10.0`; `LangVersion` removed (defaults to C# 13)
- `gitversion.yml`: `next-version` bumped to `5.0`
- CluedIn package references updated to `5.0.0-*`
- Nager.PublicSuffix updated to 3.x: `WebTldRuleProvider` → `StaticRuleProvider`; `DomainInfo.TLD` → `DomainInfo.TopLevelDomain`